### PR TITLE
feat: add precision-dependent lag to ADC measurements.

### DIFF
--- a/src/MCP3421.cpp
+++ b/src/MCP3421.cpp
@@ -46,7 +46,7 @@ int MCP3421::Begin(int _ADR) //Initialize the system in 1x gain, with 12 bit res
 int MCP3421::Begin(void) //Initialize the system in 1x gain, with 12 bit resolution, continuious conversions
 {
   SetGain(1);
-  SetResolution(12);
+  SetResolution(12); // measurement duration defaults to that required for 12 bit
   SetMode(CONTINUIOUS);
   Wire.beginTransmission(ADR);
   return Wire.endTransmission(); //Return I2C status 
@@ -70,6 +70,8 @@ long MCP3421::GetVoltageRaw(bool WaitForVal) {
       Config = GetConfig(); //Test register for new value to be read 
     }
 
+  delay(measurement_duration_ms); // Wait the requisite amount of time to take a measurement
+
   Wire.requestFrom(ADR, 4);
   
   if(Wire.available() == 4) //Get data bytes, 3 bytes of potential data and configuration register 
@@ -87,12 +89,12 @@ long MCP3421::GetVoltageRaw(bool WaitForVal) {
   if(NumBits == 14) RawADC = ((Data[0] & 0x3F) << 8) + Data[1];
   if(NumBits == 16) RawADC = ((Data[0] & 0xFF) << 8) + Data[1];
   if(NumBits == 18) RawADC = ((long(Data[0]) & 0x03) << 16) + (long(Data[1]) << 8) + Data[2];
-  
+    
   if(RawADC > pow(2, NumBits)/2 - 1) //REMOVE??
   {
     RawADC -= pow(2, NumBits) - 1;
   }
-
+  
   Config = GetConfig();  //Get congiuration register to do bit masking with
   Wire.beginTransmission(ADR);
   Wire.write(Config & 0xEF); //Clear conversion bit to ensure result is not reread 
@@ -139,6 +141,20 @@ int MCP3421::SetResolution(int DesiredResolution) {
   boolean ValidResolution = false;
   for(int i = 0; i < 4; i++){ //Test if resolution value is valid
     if(12 + 2*i == DesiredResolution) ValidResolution = true;
+  }
+
+  // Set measurement duration based on resolution  
+  if(DesiredResolution == 12){
+    measurement_duration_ms = 5;
+  }
+  else if(DesiredResolution == 14){
+    measurement_duration_ms = 17;
+  }
+  else if(DesiredResolution == 16){
+    measurement_duration_ms = 67;
+  }
+  else if(DesiredResolution == 18){
+    measurement_duration_ms = 267;
   }
 
   if(ValidResolution){ //If resolution value is valid, attempt to set new resolution

--- a/src/MCP3421.h
+++ b/src/MCP3421.h
@@ -44,7 +44,10 @@ class MCP3421
   private:
     int ADR;
     int GetConfig();
+    int measurement_duration_ms = 5; // time to wait to complete measurement
+                                     // default to 12 bits
 
 };
 
 #endif
+


### PR DESCRIPTION
The on-board ADC can be set to different resolutions, and at higher resolutions, the sampling rate is much lower.
Thus, we set the sampling rate of the ADC to make sure that enough time elapses in reading to ensure the full precision.